### PR TITLE
chore: add .claudeignore + permissions.deny

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "deny": [
+      "Read(./.env)",
+      "Read(./.env.*)",
+      "Read(**/.env)",
+      "Read(**/.env.*)",
+      "Read(**/secrets/**)",
+      "Read(**/*.pem)",
+      "Read(**/*.key)",
+      "Read(**/id_rsa)",
+      "Read(**/id_ed25519)",
+      "Read(**/credentials)",
+      "Read(**/credentials.json)",
+      "Read(**/.aws/credentials)",
+      "Read(./build/**)",
+      "Read(./.gradle/**)",
+      "Read(./out/**)"
+    ]
+  }
+}

--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,43 @@
+# Gradle build
+.gradle/
+build/
+out/
+!gradle/wrapper/gradle-wrapper.jar
+*.jar
+*.war
+*.class
+
+# IntelliJ / Eclipse
+.idea/
+*.iml
+*.ipr
+*.iws
+.classpath
+.project
+.settings/
+
+# IntelliJ Platform plugin sandbox
+.intellijPlatform/
+runIde.log
+
+# OS
+.DS_Store
+
+# Logs
+*.log
+
+# Secrets (also enforced via permissions.deny)
+.env
+.env.*
+!.env.example
+
+# Local Claude state
+.claude/settings.local.json
+.claude/sessions/
+.claude/tasks/
+.handoffs/
+
+# Backup
+*~
+.#*
+\#*

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ out/
 *.log
 bin/
 .gitnexus
+
+.handoffs/

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ out/
 
 *.log
 bin/
+.gitnexus


### PR DESCRIPTION
Per Claude Code best practices. Excludes Gradle build, IDE artifacts, IntelliJ sandbox; denies Read on .env, secrets. Tracks method-and-apparatus/hq#90.